### PR TITLE
Fix MigrateRunner._createMigrateTableIfNotExists

### DIFF
--- a/lib/migrate/migrator.js
+++ b/lib/migrate/migrator.js
@@ -107,20 +107,28 @@ function MigrateRunner(config){
   this.migrator = create(npd);
 }
 
-MigrateRunner.prototype._createMigrateTableIfNotExits = function(){
+MigrateRunner.prototype._createMigrateTableIfNotExists = function() {
   var self = this;
   var tableName = this.config.migrations.tableName;
-  return this.npd().showTables()
-  .then(function(tables){
-    var isFound = _.find(tables.TableNames, function(t){ return t === tableName });
-    if(isFound) { return; }
-
-    return self.migrator().createTable(tableName, function(t){
-      t.number('version').hashKey();
-      t.provisionedThroughput.apply(t, self.config.migrations.ProvisionedThroughput);
-    })
-    .then(function(){
-      return self.npd().rawClient().waitFor('tableExists', {TableName: tableName});
+  return new Promise(function(resolve, reject) {
+    self.npd().table(tableName).describe().then(function(_) {
+      resolve();
+    }).catch(function (err) {
+      if (!err) {
+        reject();
+      } else if (err.code === 'ResourceInUseException') {
+        resolve();
+      } else if (err.code === 'ResourceNotFoundException') {
+        self.migrator().createTable(tableName, function(t) {
+          t.number('version').hashKey();
+          t.provisionedThroughput.apply(t, self.config.migrations.ProvisionedThroughput);
+        })
+        .then(function() {
+          self.npd().rawClient().waitFor('tableExists', {TableName: tableName}).then(resolve).catch(reject);
+        }).catch(reject);
+      } else {
+        reject();
+      }
     });
   });
 };
@@ -129,7 +137,7 @@ MigrateRunner.prototype.run = function(){
   var self = this;
   var tableName = this.config.migrations.tableName;
 
-  return this._createMigrateTableIfNotExits().then(function(){
+  return this._createMigrateTableIfNotExists().then(function(){
     return self.npd().table(tableName).all().then(function(data){
       var dirs = fs.readdirSync(self.config.cwd);
 
@@ -165,6 +173,8 @@ MigrateRunner.prototype.run = function(){
 
       return utils.PromiseWaterfall(tasks);
     });
+  }).catch(function (err) {
+    console.error(err);
   });
 };
 


### PR DESCRIPTION
Same as https://github.com/noppoMan/npdynamodb/pull/72

---

`_createMigrateTableIfNotExists` now works when there are more than 100 tables (**DynamoDB has a soft limit of 256 tables per region**). Say you have 101 tables `table1` through `table100` and your migration history table's name is `table101`, the function thinks the migration history table doesn't exist, tries to create it, and then throws a `ResourceInUseException` since it really does exist.

### Changes
- renamed `_createMigrateTableIfNotExits` to `_createMigrateTableIfNotExists`
- `_createMigrateTableIfNotExists` now uses [describeTable](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#describeTable-property) instead of [listTables](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#listTables-property) to figure out if the migration history table already exists. This change was made since listTables uses pagination which defaults to 100 and describeTable can fetch one table by name.
